### PR TITLE
chore: add circle ci build-and-publish pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,67 @@
+version: 2.1
+orbs:
+  node: circleci/node@3.0.0
+jobs:
+  build:
+    executor: node/default
+    steps:
+      - checkout
+      - run:
+          name: check branch status
+          command: |
+            export GIT_COMMIT_DESC=$(git log --format=oneline -n 1 $CIRCLE_SHA1)
+            if [[ $GIT_COMMIT_DESC = *"chore(release)"* ]]; then 
+              echo "should run a job on a release commit"
+              exit 1
+            fi
+      - restore_cache:
+          key: cache-{{ checksum "package.json" }}
+      - node/install-packages:
+          with-cache: false
+      - save_cache:
+          key: cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - run:
+          name: build
+          command: npm run build
+      - persist_to_workspace:
+          root: .
+          paths: .
+
+  publish:
+    executor: node/default
+    steps:
+      - add_ssh_keys:
+          fingerprints: 92:4c:3e:93:ca:c0:b5:51:66:d7:1e:a8:2e:13:78:77
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          key: cache-{{ checksum "package.json" }}
+      - run:
+          name: config github
+          command: |
+            git config user.email circleci@circleci
+            git config user.name CircleCI
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - run:
+          name: bump and push
+          command: npm run release -- --prerelease alpha
+      - run:
+          name: publish
+          command: |
+            git push --follow-tags origin master
+            echo "//registry.npmjs.org/:_authToken=$npm_TOKEN" > .npmrc
+            npm publish
+
+workflows:
+  version: 2
+  build-and-publish:
+    jobs:
+      - build
+      - publish:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
add a workflow for CircleCI to publish the package with a commit to master

also have a workaround to prevent commit and publish a new version when the previous one is pushed 